### PR TITLE
Fix out of order imports when parsing files 

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,43 @@
+name: Deploy docs to pages
+
+on:
+  push:
+    branches: ["main"]
+
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.1
+          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+      - name: Build docs
+        run: bundle exec yard
+      - name: Setup Pages
+        uses: actions/configure-pages@v2
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: 'doc'
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1
+

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,41 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.7']
-    env:
-      RESET_STATE: true
-    steps:
-    - uses: actions/checkout@v3
-    - name: Set up Ruby
-      uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: ${{ matrix.ruby-version }}
-        bundler-cache: true # runs 'bundle install' and caches installed gems automatically
-    - name: Lint
-      run: bundle exec rubocop
-    - name: Run tests (minitest+rspec)
-      env:
-        TESTOPTS: '-v'
-      run: bundle exec rake test
-    - name: Run integration tests
-      run: |
-        bundle exec rake integration
-        bundle exec rake integration
-    - name: Upload coverage reports to Codecov
-      uses: codecov/codecov-action@v3
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}
-        files: ./coverage/coverage.xml,./rspec_coverage/coverage.xml
-    - name: Upload flutter state
-      uses: actions/upload-artifact@v3
-      with:
-        name: flutter-state
-        path: ./.flutter
-  flutter:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        ruby-version: ['2.7']
+        ruby-version: ['2.7', '3.0', '3.1']
     steps:
     - uses: actions/checkout@v3
       with:
@@ -51,7 +17,7 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby-version }}
-        bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+        bundler-cache: true
     - name: Retrieve branch point
       if: github.event_name == 'pull_request'
       run: |
@@ -67,15 +33,35 @@ jobs:
         key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ matrix.ruby-version }}-${{ github.sha }}
         restore-keys: |
           ${{ runner.os }}-build-${{ env.cache-name }}-${{ matrix.ruby-version }}-${{ steps.cache_keys.outputs.KEY }}
-    - name: Clear flutter state
+    - name: Lint
+      run: bundle exec rubocop
+    - name: Set reset state env
       if: github.event_name == 'push' && startsWith(github.ref, 'refs/heads/main')
-      run: rm -rf .flutter
+      run: |
+        echo "reset_state=true" >> $GITHUB_ENV
     - name: Run tests (minitest+rspec)
       env:
         TESTOPTS: '-v'
+        RESET_STATE: ${{ env.reset_state}}
       run: |
-        git log --oneline HEAD..${{ steps.cache_keys.outputs.KEY }}
+        echo "Test options: $TESTOPTS"
+        echo "Reset flutter state: $RESET_STATE"
         bundle exec rake test
+    - name: Run integration tests
+      if: github.event_name == 'push' && startsWith(github.ref, 'refs/heads/main')
+      run: |
+        bundle exec rake integration
+        bundle exec rake integration
+    - name: Upload coverage reports to Codecov
+      uses: codecov/codecov-action@v3
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        files: ./coverage/coverage.xml,./rspec_coverage/coverage.xml
+    - name: Upload flutter state
+      uses: actions/upload-artifact@v3
+      with:
+        name: flutter-state
+        path: ./.flutter
   release:
     needs: [test]
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,14 +35,10 @@ jobs:
           ${{ runner.os }}-build-${{ env.cache-name }}-${{ matrix.ruby-version }}-${{ steps.cache_keys.outputs.KEY }}
     - name: Lint
       run: bundle exec rubocop
-    - name: Set reset state env
-      if: github.event_name == 'push' && startsWith(github.ref, 'refs/heads/main')
-      run: |
-        echo "reset_state=true" >> $GITHUB_ENV
     - name: Run tests (minitest+rspec)
       env:
         TESTOPTS: '-v'
-        RESET_STATE: ${{ env.reset_state}}
+        RESET_STATE: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/heads/main') }}
       run: |
         echo "Test options: $TESTOPTS"
         echo "Reset flutter state: $RESET_STATE"

--- a/.yardopts
+++ b/.yardopts
@@ -1,2 +1,2 @@
---markup-provider commonmarker
+--markup-provider redcarpet
 --markup markdown

--- a/.yardopts
+++ b/.yardopts
@@ -1,0 +1,2 @@
+--markup-provider commonmarker
+--markup markdown

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- Document configuration options in README
 ### Changed
 - Delay requiring source files explicitely and only in the case where
   the constant cannot be found

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Delay requiring source files explicitely and only in the case where
   the constant cannot be found
-
+- Ensure the previous test->coverage mapping is merged with current
+  one when the test fails. This ensures that if the test failed before
+  the whole test could be exercised, we retain the previous knowledge of
+  excercised code paths.
 ## 0.2.1
 ### Fixed
 - Corrected integration examples for guard in README

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem "rake", "~> 13.0"
 
 group :development do
   gem "yard", "~> 0.9.28"
-  gem "commonmarker", "~> 0.23.6"
+  gem "redcarpet", "~> 3.5"
 end
 
 group :test, :development do

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,10 @@ gemspec
 
 gem "rake", "~> 13.0"
 
+group :development do
+  gem "yard", "~> 0.9.28"
+end
+
 group :test, :development do
   gem "pry", "~> 0.14.1"
   gem "overcommit", "~> 0.59.1"

--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gem "rake", "~> 13.0"
 
 group :development do
   gem "yard", "~> 0.9.28"
+  gem "commonmarker", "~> 0.23.6"
 end
 
 group :test, :development do

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CI](https://github.com/indydevs/flutter/actions/workflows/main.yml/badge.svg?branch=main)](https://github.com/indydevs/flutter/actions/workflows/main.yml)
 [![codecov](https://codecov.io/github/indydevs/flutter/branch/main/graph/badge.svg?token=XANF37D9C1)](https://codecov.io/github/indydevs/flutter)
 [![Gem](https://img.shields.io/gem/v/flutter)](https://rubygems.org/gems/flutter)
-[![Docs](http://img.shields.io/badge/yard-docs-blue.svg)](http://www.rubydoc.info/gems/flutter)
+[![Docs](http://img.shields.io/badge/yard-docs-blue.svg)](https://flutter.indydevs.org)
 
 ```
  __   __

--- a/README.md
+++ b/README.md
@@ -43,21 +43,11 @@ a signature for all the methods that were exercised. On subsequent runs Flutter 
   ```ruby
   require 'flutter'
   ```
-- Enable & configure it in your `test_helper.rb`:
+- Enable & configure it in your `test_helper.rb` (See [Configuration options](#configuration-options) for available options):
 
   ```ruby
   Flutter.configure do |config|
     config.enabled = true
-    # Paths to consider when tracking test -> source mappings. Default: Dir.pwd/*
-    config.sources = ["./app/*", "./test/*"]
-    # Paths to ignore for tracking test -> source. Default: ./vendor
-    config.exclusions = ["./vendor/*"]
-    # Storage type. Default: Flutter::Persistence::Marshal
-    config.storage_class = Flutter::Persistence::Marshal
-    # Where to store the state. Default: ./.flutter
-    config.storage_options = {path: "./.flutter"}
-    # Whether to reset the stored state before the test run. Default: false
-    config.reset_storage = false
   end
   ```
 - Run your test suite the way you normally would (for example: `bundle exec rake test`). The first run will run all
@@ -88,21 +78,11 @@ end
   ```ruby
   require 'flutter'
   ```
-- Enable & configure it in your `spec_helper.rb`:
+- Enable & configure it in your `spec_helper.rb` (See [Configuration options](#configuration-options) for available options):
 
   ```ruby
   Flutter.configure do |config|
     config.enabled = true
-    # Paths to consider when tracking test -> source mappings. Default: Dir.pwd/*
-    config.sources = ["./app/*", "./lib/*", "./spec/*"]
-    # Paths to ignore for tracking test -> source. Default: ./vendor
-    config.exclusions = ["./vendor/*"]
-    # Storage type. Default: Flutter::Persistence::Marshal
-    config.storage_class = Flutter::Persistence::Marshal
-    # Where to store the state. Default: ./.flutter
-    config.storage_options = {path: "./.flutter"}
-    # Whether to reset the stored state before the test run. Default: false
-    config.reset_storage = false
   end
   ```
 - Run your specs the way you normally would (for example: `bundle exec rspec`). The first run will run all
@@ -120,6 +100,21 @@ guard :rspec, cmd: "rspec" do
   watch(%r{^(spec|app|lib)/(.*/)?([^/]+)\.rb$}) { "spec" }
 end
 ```
+
+### Configuration options
+|      option       | Description                                                    |                  Type                   |             Default             |
+|:-----------------:|:---------------------------------------------------------------|:---------------------------------------:|:-------------------------------:|
+|     `enabled`     | Whether flutter is enabled                                     |         `TrueClass, FalseClass`         |             `true`              |
+|     `sources`     | List of glob style expressions to select source files to track |                  `Set`                  |       `["#{Dir.pwd}/*"]`        |
+|   `exclusions`    | List of glob style expressions to exclude sources files        |                  `Set`                  |   `["#{Dir.pwd}/vendor}/*"]`    |
+|  `storage_class`  | The storage class to use for persisting the state              | `Flutter::Persistence::AbstractStorage` | `Flutter::Persistence::Marshal` |
+| `storage_options` | Additional options to pass to the storage class                |                 `Hash`                  |     `{path: './.flutter'}`      |
+|  `reset_storage`  | Whether to clear the persisted state on initialization         |         `TrueClass, FalseClass`         |             `false`             |
+
+
+
+
+
 ## Configuring flutter in continuous integration
 
 Flutter can be used in continuous integration environments to speed up the turn

--- a/flutter.gemspec
+++ b/flutter.gemspec
@@ -12,16 +12,15 @@ Gem::Specification.new do |spec|
   spec.description = 'Flutter plugs in to your RSpec or Minitest test suites
   and helps you run only the tests that exercise the code you have changed since the last run
   '
-  spec.homepage = "https://github.com/indydevs/flutter"
+  spec.homepage = "https://flutter.indydevs.org"
   spec.license = "MIT"
   spec.required_ruby_version = ">= 2.7.0"
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/indydevs/flutter"
-  spec.metadata["changelog_uri"] = "https://github.com/indydevs/flutter/blob/master/CHANGELOG.md"
-
-  # Specify which files should be added to the gem when it is released.
-  # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
+  spec.metadata["bug_tracker_uri"] = "#{spec.metadata["source_code_uri"]}/issues"
+  spec.metadata["changelog_uri"] = "#{spec.metadata["source_code_uri"]}/blob/master/CHANGELOG.md"
+  spec.metadata["ducmentation_uri"] = spec.homepage
   spec.files = Dir.chdir(__dir__) do
     %x(git ls-files -z).split("\x0").reject do |f|
       (f == __FILE__) || f.match(
@@ -34,7 +33,4 @@ Gem::Specification.new do |spec|
   spec.add_dependency("deep_merge", " ~> 1.2")
   spec.add_dependency("dry-configurable", "~> 0.15")
   spec.add_dependency("parser", "~> 3.1")
-
-  # For more information and examples about making a new gem, check out our
-  # guide at: https://bundler.io/guides/creating_gem.html
 end

--- a/lib/flutter.rb
+++ b/lib/flutter.rb
@@ -7,6 +7,5 @@ require_relative "flutter/rspec"
 require_relative "flutter/persistence"
 
 module Flutter
-  class Error < StandardError; end
   include Flutter::Config
 end

--- a/lib/flutter/minitest.rb
+++ b/lib/flutter/minitest.rb
@@ -62,7 +62,7 @@ module Flutter
       end
 
       def before_teardown
-        Minitest.flutter_tracker&.stop if ::Flutter.enabled
+        Minitest.flutter_tracker&.stop(location, failures.empty?) if ::Flutter.enabled
         super
       end
     end

--- a/lib/flutter/rspec.rb
+++ b/lib/flutter/rspec.rb
@@ -52,7 +52,8 @@ if defined?(RSpec.configure)
     config.around(:each) do |example|
       Flutter::RSpec.tracker.start(example.full_description) if Flutter.enabled
       example.run
-      Flutter::RSpec.tracker.stop if Flutter.enabled
+      Flutter::RSpec.tracker.stop(example.full_description,
+        example.execution_result.exception.nil?) if Flutter.enabled
     end
 
     config.after(:suite) do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,6 +23,6 @@ require "flutter"
 Flutter.configure do |config|
   config.sources << Dir.pwd
   config.storage_options = { path: "./.flutter/rspec" }
-  config.reset_storage = ENV["RESET_STATE"]
+  config.reset_storage = ENV["RESET_STATE"] == "true"
   config.enabled = true
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -19,7 +19,7 @@ require "flutter"
 
 Flutter.configure do |config|
   config.enabled = true
-  config.reset_storage = ENV["RESET_STATE"]
+  config.reset_storage = ENV["RESET_STATE"] == "true"
 end
 
 require "minitest"


### PR DESCRIPTION
# Description

Avoid always importing the file that is being parsed for signatures as in most cases this might already be loaded, and more importantly, loaded in the right order. 

Only if the class/module can't be found with `Kernel.const_get` resort to require_relative.

This was noticed when testing against the `omniauth` library with dependencies vendored and tracked.